### PR TITLE
Fix time discrepancy due to timezone calculations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,21 +3,21 @@ const friendsData = {
     ravi: {
         name: 'Ravi',
         location: 'Toronto',
-        moveDate: new Date('2025-09-01T00:00:00'),
+        moveDate: new Date('2025-09-01T00:00:00Z'),
         coordinates: [43.651070, -79.347015],
         avatar: './assets/ravi_avatar.jpeg'
     },
     arjun: {
         name: 'Arjun',
         location: 'Sunnyvale',
-        moveDate: new Date('2025-12-01T00:00:00'),
+        moveDate: new Date('2025-12-01T00:00:00Z'),
         coordinates: [37.368832, -122.036346],
         avatar: './assets/arjun_avatar.jpeg'
     },
     nick: {
         name: 'Nick',
         location: 'Seattle',
-        moveDate: new Date('2026-06-01T00:00:00'),
+        moveDate: new Date('2026-06-01T00:00:00Z'),
         coordinates: [47.608013, -122.335167],
         avatar: './assets/nick_avatar.jpeg'
     }


### PR DESCRIPTION
### Summary 

This PR updates the moveDate values for each friend to use ISO 8601 UTC format (e.g., '2025-12-01T00:00:00Z') instead of local time. This ensures consistent countdown calculations across different browsers and time zones, and fixes a bug where Arjun's countdown appeared 1 hour ahead due to daylight saving time differences.
